### PR TITLE
Fixed error about line 196 circle function error

### DIFF
--- a/OpenCVAnimOperator.py
+++ b/OpenCVAnimOperator.py
@@ -193,11 +193,11 @@ class OpenCVAnimOperator(bpy.types.Operator):
                     
                     # draw face markers
                     for (x, y) in shape:
-                        cv2.circle(image, (x, y), 2, (0, 255, 255), -1)
+                        cv2.circle(image, (int(x), int(y)), 2, (0, 255, 255), -1)
             
             # draw detected face
             for (x,y,w,h) in faces:
-                cv2.rectangle(image,(x,y),(x+w,y+h),(255,0,0),1)
+                cv2.rectangle(image,(int(x),int(y)),(int(x+w),int(y+h)),(255,0,0),1)
             
             # Show camera image in a window                     
             cv2.imshow("Output", image)


### PR DESCRIPTION
Blender produces an error when the shape is split into  x and y so I  implicitly assigning them of type int. I also implicitly assigned the x and y additions in the rectangle function. Following the comments from @barckley75 https://github.com/jkirsons/FacialMotionCapture_v2/issues/4#issuecomment-850978674 